### PR TITLE
Fix ListenAndServeTLS to use GetCertificate correctly

### DIFF
--- a/cmd/webhook/main.go
+++ b/cmd/webhook/main.go
@@ -67,7 +67,7 @@ func main() {
 			},
 		}
 
-		err := httpServer.ListenAndServeTLS(*cert, *key)
+		err := httpServer.ListenAndServeTLS("", "")
 		if err != nil {
 			glog.Fatalf("error starting web server: %v", err)
 		}


### PR DESCRIPTION
See following PR for the detail.
https://github.com/golang/go/commit/6a208efbdfa939dc236a63383df19c7ab44aa50a