### PR TITLE
Dev/move to alpine linux

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/sh
 set -e
 
 DEST_DIR="bin"

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:1.12
+FROM golang:1.15-alpine
 
 ENV PKG_NAME=github.com/k8snetworkplumbingwg/net-attach-def-admission-controller
 ENV PKG_PATH=$GOPATH/src/$PKG_NAME

--- a/deployments/deployment.yaml
+++ b/deployments/deployment.yaml
@@ -28,7 +28,7 @@ spec:
     spec:
       containers:
       - name: net-attach-def-admission-controller
-        image: nfvpe/net-attach-def-admission-controller:snapshot
+        image: bcmt-registry:5000/net-attach-def-admission-controller:latest
         command:
         - ./bin/webhook
         args:
@@ -42,9 +42,16 @@ spec:
         - name: webhook-certs
           mountPath: /etc/webhook
           readOnly: True
+        - name: os-net-config
+          mountPath: /etc/os-net-config
+          readOnly: True
         imagePullPolicy: IfNotPresent
       serviceAccountName: net-attach-def-admission-controller-sa
       volumes:
       - name: webhook-certs
         secret:
           secretName: net-attach-def-admission-controller-secret
+      - name: os-net-config
+        hostPath:
+          path: /etc/os-net-config
+          type: Directory

--- a/deployments/roles.yaml
+++ b/deployments/roles.yaml
@@ -5,6 +5,32 @@ metadata:
   name: net-attach-def-admission-controller-sa
   namespace: kube-system
 ---
+apiVersion: policy/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  name: net-attach-def-admission-controller-psp
+  annotations:
+    seccomp.security.alpha.kubernetes.io/allowedProfileNames: '*'
+    seccomp.security.alpha.kubernetes.io/defaultProfileName:  'docker/default'
+spec:
+  privileged: false
+  allowPrivilegeEscalation: false
+  allowedCapabilities:
+  - '*'
+  volumes:
+  - '*'
+  hostNetwork: false
+  hostIPC: false
+  hostPID: false
+  runAsUser:
+    rule: 'RunAsAny'
+  seLinux:
+    rule: 'RunAsAny'
+  supplementalGroups:
+    rule: 'RunAsAny'
+  fsGroup:
+    rule: 'RunAsAny'
+---
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
@@ -16,7 +42,14 @@ rules:
 - apiGroups: ["k8s.cni.cncf.io"]
   resources: ["network-attachment-definitions"]
   verbs: ["get", "watch", "list"]
-
+- apiGroups:
+  - extensions
+  resources:
+  - podsecuritypolicies
+  resourceNames:
+  - net-attach-def-admission-controller-psp
+  verbs:
+  - use
 ---
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1


### PR DESCRIPTION
This patch is to reduce the footprint of this admission controller. By moving the base OS from Debian to Apline Linux, the docker image size is cut in half.
