### PR TITLE
This is a simple patch to cut docker image size in half by moving to …

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/sh
 set -e
 
 DEST_DIR="bin"

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:1.12
+FROM golang:1.15-alpine
 
 ENV PKG_NAME=github.com/k8snetworkplumbingwg/net-attach-def-admission-controller
 ENV PKG_PATH=$GOPATH/src/$PKG_NAME


### PR DESCRIPTION
…alpine linux.

$ sudo docker images
REPOSITORY                            TAG                 IMAGE ID            CREATED             SIZE
net-attach-def-admission-controller   alpine              67df5f1747d2        20 minutes ago      498 MB
net-attach-def-admission-controller   latest              67df5f1747d2        20 minutes ago      498 MB
net-attach-def-admission-controller   debian              6a0c90676c64        52 minutes ago      980 MB
docker.io/golang                      1.15-alpine         3dae2ccc15b8        8 days ago          299 MB
docker.io/golang                      1.12                ffcaee6f7d8b        12 months ago       810 MB

Signed-off-by: Jing.C.Zhang <jing.c.zhang@nokia.com>