### PR TITLE
Fixes pod not responding to sigterm

### DIFF
--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -112,8 +112,7 @@ func StartWatching() {
 	go c.Run(stopCh)
 
 	sigterm := make(chan os.Signal, 1)
-	signal.Notify(sigterm, syscall.SIGTERM)
-	signal.Notify(sigterm, syscall.SIGINT)
+	signal.Notify(sigterm, syscall.SIGINT, syscall.SIGTERM, syscall.SIGKILL)
 	<-sigterm
 }
 


### PR DESCRIPTION
Fixed bug that was causing multus admission controller pods to not die when SIGTERM is encountered

Reported in https://issues.redhat.com/browse/SDN-2505