### PR TITLE
Fixed name auto insertion in CNI config

### DIFF
--- a/pkg/webhook/webhook.go
+++ b/pkg/webhook/webhook.go
@@ -87,10 +87,13 @@ func validateCNIConfig(config []byte) error {
 func preprocessCNIConfig(name string, config []byte) ([]byte, error) {
 	var c map[string]interface{}
 	if err := json.Unmarshal(config, &c); err != nil {
-		if n, ok := c["name"]; !ok || n == "" {
-			c["name"] = name
-		}
+		return nil, err
 	}
+
+	if n, ok := c["name"]; !ok || n == "" {
+		c["name"] = name
+	}
+
 	configBytes, err := json.Marshal(c)
 	return configBytes, err
 }

--- a/pkg/webhook/webhook_test.go
+++ b/pkg/webhook/webhook_test.go
@@ -205,5 +205,36 @@ var _ = Describe("Webhook", func() {
 			},
 			true, false,
 		),
+		Entry(
+			"validate missing name in config",
+			netv1.NetworkAttachmentDefinition{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "some-valid-name",
+				},
+				Spec: netv1.NetworkAttachmentDefinitionSpec{
+					Config: `{
+						"cniVersion": "0.3.0",
+						"plugins": [{
+							"type": "bridge",
+							"bridge": "br0",
+							"ipam": {
+								"type": "host-local",
+								"subnet": "192.168.1.0/24"
+							}
+						},
+						{
+							"type": "some-plugin"
+						},
+						{
+							"type": "another-plugin",
+							"sysctl": {
+								"net.ipv4.conf.all.log_martians": "1"
+							}
+						}]
+					}`,
+				},
+			},
+			true, false,
+		),
 	)
 })


### PR DESCRIPTION
With existing code, if 'name' not provided in CNI config then, Network-Attachment-Definition creation was failing with 'no name' and 'invalid config' error.

Error was like: 'admission webhook "multus-validating-config.k8s.io" denied the request: invalid config'

Modified code to auto insert 'name' in CNI config and added unit test for the same.