### PR TITLE
OCPBUGS-85053: Bump Go version to 1.25.0 for ML-KEM/PQC support

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,7 +4,7 @@ jobs:
   build:
     strategy:
       matrix:
-        go-version: [1.24.x]
+        go-version: [1.25.x]
         os: [ubuntu-latest]
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,7 +4,7 @@ jobs:
   test:
     strategy:
       matrix:
-        go-version: [1.24.x]
+        go-version: [1.25.x]
         os: [ubuntu-latest]
     runs-on: ${{ matrix.os }}
     steps:

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:1.24
+FROM golang:1.25
 
 LABEL org.opencontainers.image.source=https://github.com/k8snetworkplumbingwg/net-attach-def-admission-controller
 ADD . /usr/src/net-attach-def-admission-controller

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/k8snetworkplumbingwg/net-attach-def-admission-controller
 
-go 1.24.0
+go 1.25.9
 
 require (
 	github.com/containernetworking/cni v1.3.0


### PR DESCRIPTION
This upgrade enables ML-KEM key encapsulation during TLS 1.3 handshakes. Go 1.25 includes refined ML-KEM negotiation logic that allows the webhook server to automatically support post-quantum cryptography without code changes to the TLS configuration.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Go version to 1.25 in build pipelines, test workflows, container configuration, and project dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->