### PR TITLE
NO-JIRA: Remove TLS min version validation for OpenShift profile compatibility

### DIFF
--- a/cmd/webhook/main.go
+++ b/cmd/webhook/main.go
@@ -171,11 +171,6 @@ func startHTTPServers(config *ServerConfig) (func(), error) {
 		if err != nil {
 			return nil, fmt.Errorf("error parsing TLS min version %q: %w", config.TLSMinVersion, err)
 		}
-
-		// Validate that the minimum TLS version is at least TLS 1.2
-		if tlsMinVersionID < tls.VersionTLS12 {
-			return nil, fmt.Errorf("TLS min version %q is below the minimum required version TLS 1.2", config.TLSMinVersion)
-		}
 	}
 
 	applyTLSOptions := func(to *tls.Config) *tls.Config {

--- a/cmd/webhook/main_test.go
+++ b/cmd/webhook/main_test.go
@@ -131,24 +131,15 @@ func testHTTPServers() {
 		})
 	})
 
-	DescribeTable("should reject TLS min versions below TLS 1.2",
-		func(version string) {
-			config.TLSMinVersion = version
-			_, err := startHTTPServers(config)
-			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(ContainSubstring("below the minimum required version TLS 1.2"))
-		},
-		Entry("TLS 1.0", "VersionTLS10"),
-		Entry("TLS 1.1", "VersionTLS11"),
-	)
-
-	DescribeTable("should accept TLS min versions at or above TLS 1.2",
+	DescribeTable("should accept all TLS min versions",
 		func(version string) {
 			config.TLSMinVersion = version
 			var err error
 			cleanup, err = startHTTPServers(config)
 			Expect(err).NotTo(HaveOccurred())
 		},
+		Entry("TLS 1.0", "VersionTLS10"),
+		Entry("TLS 1.1", "VersionTLS11"),
 		Entry("TLS 1.2", "VersionTLS12"),
 		Entry("TLS 1.3", "VersionTLS13"),
 	)


### PR DESCRIPTION
Removed the validation that enforced TLS 1.2 as the minimum version when the `--tls-min-version` CLI flag is specified. This allows OpenShift TLS profiles that support older versions (e.g., the "Old" profile with TLS 1.0) to be used when explicitly configured.

When `--tls-min-version` is not specified, the webhook server still defaults to TLS 1.2, maintaining secure defaults while allowing backwards compatibility when needed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Removed the enforcement of a minimum TLS version requirement that previously restricted configurations to TLS 1.2 and above. The webhook now supports lower TLS versions, providing better compatibility with legacy systems and infrastructure environments

* **Tests**
  * Reorganized and expanded the test suite to thoroughly validate all supported TLS versions, including legacy versions TLS 1.0 and 1.1, as well as current versions 1.2 and above

<!-- end of auto-generated comment: release notes by coderabbit.ai -->